### PR TITLE
Add Overloads to Support Cancellation via CancellationTokens

### DIFF
--- a/src/Restivus/HttpRequestSender.cs
+++ b/src/Restivus/HttpRequestSender.cs
@@ -70,7 +70,7 @@ namespace Restivus
             Logger?.Debug("{message}", message);
 
             using (message)
-            using (var response = await HttpClient.SendAsync(message, CancellationToken.None))
+            using (var response = await HttpClient.SendAsync(message, token))
             {
                 response.EnsureSuccessStatusCode();
 

--- a/src/Restivus/RestClient.cs
+++ b/src/Restivus/RestClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Restivus
@@ -88,11 +89,32 @@ namespace Restivus
             Action<HttpRequestMessage> mutateRequestMessage,
             Func<HttpResponseMessage, TResponse> deserializeResponse)
         {
+            return client.SendAsync(
+                method,
+                relativePath,
+                mutateRequestMessage,
+                deserializeResponse,
+                CancellationToken.None
+            );
+        }
+
+        public static Task<TResponse> SendAsync<TResponse>(
+            this IRestClient client,
+            HttpMethod method,
+            string relativePath,
+            Action<HttpRequestMessage> mutateRequestMessage,
+            Func<HttpResponseMessage, TResponse> deserializeResponse,
+            CancellationToken token)
+        {
             var message = client.CreateRequestMessage(method, relativePath);
 
             mutateRequestMessage(message);
 
-            return client.RequestSender.SendAsync(message, deserializeResponse);
+            return client.RequestSender.SendAsync(
+                message,
+                deserializeResponse,
+                token
+            );
         }
 
         public static Task<TResponse> SendAsync<TResponse>(
@@ -102,11 +124,32 @@ namespace Restivus
             Action<HttpRequestMessage> mutateRequestMessage,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync)
         {
+            return client.SendAsync(
+                method,
+                relativePath,
+                mutateRequestMessage,
+                deserializeResponseAsync,
+                CancellationToken.None
+            );
+        }
+
+        public static Task<TResponse> SendAsync<TResponse>(
+            this IRestClient client,
+            HttpMethod method,
+            string relativePath,
+            Action<HttpRequestMessage> mutateRequestMessage,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken token)
+        {
             var message = client.CreateRequestMessage(method, relativePath);
 
             mutateRequestMessage(message);
 
-            return client.RequestSender.SendAsync(message, deserializeResponseAsync);
+            return client.RequestSender.SendAsync(
+                message,
+                deserializeResponseAsync,
+                token
+            );
         }
     }
 }

--- a/src/Restivus/RestClient.cs
+++ b/src/Restivus/RestClient.cs
@@ -16,23 +16,6 @@ namespace Restivus
 
     public static class RestClientExtensions
     {
-        static HttpRequestMessage _CreateRequestMessage(
-            this IRestClient client,
-            HttpMethod method,
-            string path,
-            Func<string, Uri> buildUriFromPath)
-        {
-            var message = new HttpRequestMessage(
-                method,
-                buildUriFromPath(path)
-            );
-
-            return client.RequestMiddlewares.Aggregate(
-                message,
-                (msg, middleware) => middleware?.Run(message)
-            );
-        }
-
         public static ISingleMethodRequestSender For(
             this IRestClient client,
             HttpMethod method,
@@ -51,6 +34,23 @@ namespace Restivus
         public static ISingleMethodRequestSender Post(
             this IRestClient client,
             Func<object, HttpContent> buildContent) => client.For(HttpMethod.Post, buildContent);
+
+        static HttpRequestMessage _CreateRequestMessage(
+            this IRestClient client,
+            HttpMethod method,
+            string path,
+            Func<string, Uri> buildUriFromPath)
+        {
+            var message = new HttpRequestMessage(
+                method,
+                buildUriFromPath(path)
+            );
+
+            return client.RequestMiddlewares.Aggregate(
+                message,
+                (msg, middleware) => middleware?.Run(message)
+            );
+        }
 
         public static HttpRequestMessage CreateRequestMessageForRelativePath(
             this IRestClient client,

--- a/src/Restivus/SingleMethodRequestSender.cs
+++ b/src/Restivus/SingleMethodRequestSender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Restivus
@@ -14,22 +15,56 @@ namespace Restivus
 
         Task<string> SendAsync(string path);
 
+        Task<string> SendAsync(string path, CancellationToken token);
+
         Task<string> SendAsync(
             string path,
             Action<HttpRequestMessage> mutateRequest);
+
+        Task<string> SendAsync(
+            string path,
+            Action<HttpRequestMessage> mutateRequest,
+            CancellationToken token);
 
         Task<string> SendAsync<TPayload>(
             string path,
             TPayload payload);
 
+        Task<string> SendAsync<TPayload>(
+            string path,
+            TPayload payload,
+            CancellationToken token);
+
+        [Obsolete("Don't worry about implementing this yet, since it's brand new")]
+        Task<string> SendAsync<TPayload>(
+            string path,
+            Func<TPayload> getPayload);
+
+        [Obsolete("Don't worry about implementing this yet, since it's brand new")]
+        Task<string> SendAsync<TPayload>(
+            string path,
+            Func<TPayload> getPayload,
+            CancellationToken token);
+
         Task<TResponse> SendAsync<TResponse>(
             string path,
             Func<HttpResponseMessage, Task<TResponse>> deserializeAsync);
 
         Task<TResponse> SendAsync<TResponse>(
             string path,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
+
+        Task<TResponse> SendAsync<TResponse>(
+            string path,
             Action<HttpRequestMessage> mutateRequest,
             Func<HttpResponseMessage, Task<TResponse>> deserializeAsync);
+
+        Task<TResponse> SendAsync<TResponse>(
+            string path,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
 
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
@@ -38,8 +73,20 @@ namespace Restivus
 
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
+            TPayload payload,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
             Func<TPayload> getPayload,
             Func<HttpResponseMessage, Task<TResponse>> deserializeAsync);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            Func<TPayload> getPayload,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
 
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
@@ -49,9 +96,23 @@ namespace Restivus
 
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
+            TPayload getPayload,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
             Func<TPayload> getPayload,
             Action<HttpRequestMessage> mutateRequest,
             Func<HttpResponseMessage, Task<TResponse>> deserializeAsync);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            Func<TPayload> getPayload,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeAsync,
+            CancellationToken token);
     }
 
     public class SingleMethodRequestSender : ISingleMethodRequestSender
@@ -74,12 +135,22 @@ namespace Restivus
 
         public Task<string> SendAsync(string path) => SendAsync(path, message => { });
 
+        public Task<string> SendAsync(string path, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<string> SendAsync(string path, Action<HttpRequestMessage> mutateRequest)
         {
             return SendAsync(
                 path,
                 mutateRequest,
                 async response => await response.Content.ReadAsStringAsync());
+        }
+
+        public Task<string> SendAsync(string path, Action<HttpRequestMessage> mutateRequest, CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<string> SendAsync<TPayload>(string path, TPayload payload)
@@ -90,9 +161,30 @@ namespace Restivus
                 async response => await response.Content.ReadAsStringAsync());
         }
 
+        public Task<string> SendAsync<TPayload>(string path, TPayload payload, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> SendAsync<TPayload>(string path, Func<TPayload> getPayload)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> SendAsync<TPayload>(string path, Func<TPayload> getPayload, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<TResponse> SendAsync<TResponse>(string path, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
             return SendAsync(path, request => { }, deserializeAsync);
+        }
+
+
+        public Task<TResponse> SendAsync<TResponse>(string path, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<TResponse> SendAsync<TResponse>(string path, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
@@ -100,9 +192,19 @@ namespace Restivus
             return _RestClient.SendAsync(HttpMethod, path, mutateRequest, deserializeAsync);
         }
 
+        public Task<TResponse> SendAsync<TResponse>(string path, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
             return SendAsync(path, () => payload, deserializeAsync);
+        }
+
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
@@ -114,6 +216,11 @@ namespace Restivus
                 deserializeAsync);
         }
 
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
             return SendAsync(
@@ -121,6 +228,11 @@ namespace Restivus
                 () => payload,
                 mutateRequest,
                 deserializeAsync);
+        }
+
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
@@ -135,6 +247,11 @@ namespace Restivus
                 },
                 deserializeAsync
             );
+        }
+
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Restivus/SingleMethodRequestSender.cs
+++ b/src/Restivus/SingleMethodRequestSender.cs
@@ -35,12 +35,10 @@ namespace Restivus
             TPayload payload,
             CancellationToken token);
 
-        [Obsolete("Don't worry about implementing this yet, since it's brand new")]
         Task<string> SendAsync<TPayload>(
             string path,
             Func<TPayload> getPayload);
 
-        [Obsolete("Don't worry about implementing this yet, since it's brand new")]
         Task<string> SendAsync<TPayload>(
             string path,
             Func<TPayload> getPayload,
@@ -133,78 +131,87 @@ namespace Restivus
 
         public HttpMethod HttpMethod { get; }
 
-        public Task<string> SendAsync(string path) => SendAsync(path, message => { });
+        public Task<string> SendAsync(string path) => SendAsync(path, CancellationToken.None);
 
-        public Task<string> SendAsync(string path, CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<string> SendAsync(string path, CancellationToken token) =>
+            SendAsync(
+                path,
+                request => { },
+                token
+            );
 
         public Task<string> SendAsync(string path, Action<HttpRequestMessage> mutateRequest)
         {
-            return SendAsync(
-                path,
-                mutateRequest,
-                async response => await response.Content.ReadAsStringAsync());
+            return SendAsync(path, mutateRequest, CancellationToken.None);
         }
 
         public Task<string> SendAsync(string path, Action<HttpRequestMessage> mutateRequest, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(
+                path,
+                mutateRequest,
+                async response => await response.Content.ReadAsStringAsync(),
+                token
+            );
         }
 
         public Task<string> SendAsync<TPayload>(string path, TPayload payload)
         {
-            return SendAsync(
-                path,
-                payload,
-                async response => await response.Content.ReadAsStringAsync());
+            return SendAsync(path, payload, CancellationToken.None);
         }
 
         public Task<string> SendAsync<TPayload>(string path, TPayload payload, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(
+                path,
+                () => payload,
+                token
+            );
         }
 
         public Task<string> SendAsync<TPayload>(string path, Func<TPayload> getPayload)
         {
-            throw new NotImplementedException();
+            return SendAsync(path, getPayload, CancellationToken.None);
         }
 
         public Task<string> SendAsync<TPayload>(string path, Func<TPayload> getPayload, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(
+                path,
+                getPayload,
+                async response => await response.Content.ReadAsStringAsync(),
+                token
+            );
         }
 
         public Task<TResponse> SendAsync<TResponse>(string path, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
-            return SendAsync(path, request => { }, deserializeAsync);
+            return SendAsync(path, deserializeAsync, CancellationToken.None);
         }
-
 
         public Task<TResponse> SendAsync<TResponse>(string path, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(path, request => { }, deserializeAsync, token);
         }
 
         public Task<TResponse> SendAsync<TResponse>(string path, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
-            return _RestClient.SendAsync(HttpMethod, path, mutateRequest, deserializeAsync);
+            return SendAsync(path, mutateRequest, deserializeAsync, CancellationToken.None);
         }
 
         public Task<TResponse> SendAsync<TResponse>(string path, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return _RestClient.SendAsync(HttpMethod, path, mutateRequest, deserializeAsync, token);
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
-            return SendAsync(path, () => payload, deserializeAsync);
+            return SendAsync(path, payload, deserializeAsync, CancellationToken.None);
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(path, () => payload, deserializeAsync, token);
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
@@ -212,30 +219,55 @@ namespace Restivus
             return SendAsync(
                 path,
                 getPayload,
-                _ => { },
-                deserializeAsync);
+                deserializeAsync,
+                CancellationToken.None);
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(
+                path,
+                getPayload,
+                _ => { },
+                deserializeAsync,
+                token
+            );
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
         {
             return SendAsync(
                 path,
-                () => payload,
+                payload,
                 mutateRequest,
-                deserializeAsync);
+                deserializeAsync,
+                CancellationToken.None
+            );
         }
 
-        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, TPayload payload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return SendAsync(
+                path,
+                () => payload,
+                mutateRequest,
+                deserializeAsync,
+                token
+            );
         }
 
         public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync)
+        {
+            return SendAsync(
+                path,
+                getPayload,
+                mutateRequest,
+                deserializeAsync,
+                CancellationToken.None
+            );
+        }
+
+        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
         {
             return _RestClient.SendAsync(
                 HttpMethod,
@@ -245,13 +277,9 @@ namespace Restivus
                     request.Content = _createRequestContent(getPayload());
                     mutateRequest(request);
                 },
-                deserializeAsync
+                deserializeAsync,
+                token
             );
-        }
-
-        public Task<TResponse> SendAsync<TPayload, TResponse>(string path, Func<TPayload> getPayload, Action<HttpRequestMessage> mutateRequest, Func<HttpResponseMessage, Task<TResponse>> deserializeAsync, CancellationToken token)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/test/Restivus.Tests/GitHubExample.cs
+++ b/test/Restivus.Tests/GitHubExample.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -62,6 +63,23 @@ namespace Restivus.Tests
             );
 
             Assert.NotEmpty(users);
+        }
+
+        [Fact]
+        public async Task CancellationIsSupported()
+        {
+            var tokenSource = new CancellationTokenSource();
+            var client = new GitHubRestClient();
+
+            tokenSource.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => client.Get().SendAsync(
+                    "/users",
+                    _DeserializeMany<User>,
+                    tokenSource.Token
+                )
+            );
         }
 
         static async Task<T> _Deserialize<T>(HttpResponseMessage response)


### PR DESCRIPTION
CancellationTokens can now be passed in pretty much anywhere.

[Usage example here](https://github.com/awseward/restivus/compare/cancellation#diff-d7798b3c05d0b7a821e4570b02425da1R68)

Issue link: https://github.com/awseward/restivus/issues/3
