### PR TITLE
Remove EnsureSuccessStatusCode

### DIFF
--- a/src/Restivus/HttpRequestSender.cs
+++ b/src/Restivus/HttpRequestSender.cs
@@ -72,8 +72,6 @@ namespace Restivus
             using (message)
             using (var response = await HttpClient.SendAsync(message, token))
             {
-                response.EnsureSuccessStatusCode();
-
                 Logger?.Debug("{response}", response);
 
                 var responseContent = await deserializeResponseContentAsync(response);


### PR DESCRIPTION
It only limits flexibility in terms of error handling approaches.

If the calling code wants to use it, it can use it.
