### PR TITLE
Do not double-log response messages

### DIFF
--- a/src/Restivus/HttpRequestSender.cs
+++ b/src/Restivus/HttpRequestSender.cs
@@ -76,7 +76,14 @@ namespace Restivus
 
                 var responseContent = await deserializeResponseContentAsync(response);
 
-                Logger?.Debug("{@responseContent}", responseContent);
+                {
+                    var asResponseMessage = responseContent as HttpResponseMessage;
+
+                    if (asResponseMessage == null || asResponseMessage != response)
+                    {
+                        Logger?.Debug("{@responseContent}", responseContent);
+                    }
+                }
 
                 return responseContent;
             }


### PR DESCRIPTION
In some cases, a consumer wants to do a PUT, POST, ect, but does not
care about what comes back. One way to do this is to provide a
`deserializeResponseContentAsync` that is more or less just the
following.

``` cs
// ...
response => Task.FromResult(response)
// ...
```

The trouble with this, however, is that the default implementation of
`IHttpRequestSender` logs the "response content" after it is
deserialized, no matter what. So this adds a check to avoid logging our
"response content" if it is an HttpResponseMessage which is equal to the
actual response.
