### PR TITLE
docs: Deprecate non-async deserializeResponse

### DIFF
--- a/src/Restivus/RestClient.cs
+++ b/src/Restivus/RestClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -82,6 +83,40 @@ namespace Restivus
             HttpMethod method,
             string path) => client.CreateRequestMessageForRelativePath(method, path);
 
+        /// <summary>
+        /// This overload's use is discouraged, as it can cause subtle misbehavior when
+        /// attempting to await a Task and only catch an Exception it may throw.
+        /// </summary>
+        /// <example>
+        /// try
+        /// {
+        ///     await restClient
+        ///         .SendAsync(
+        ///             HttpMethod.Get,
+        ///             "/health_check",
+        ///             request => { },
+        ///             async response =>
+        ///             {
+        ///                 if (_DetectFailureState(response))
+        ///                 {
+        ///                     var ex = await _ConvertFailedResponseToRelevantException(response);
+        ///                     throw ex;
+        ///                 }
+        ///
+        ///                 // The correctly intended overload will be chosen if you uncomment the
+        ///                 // following line, but callsites are bound to be missing this detail
+        ///                 //
+        ///                 // return Task.CompletedTask;
+        ///             });
+        /// }
+        /// catch (Exception ex)
+        /// {
+        ///     // Execution will not reach this spot.
+        /// }
+        ///
+        /// </example>
+        [Obsolete("Prefer deserializeResponseAsync overload")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Task<TResponse> SendAsync<TResponse>(
             this IRestClient client,
             HttpMethod method,
@@ -98,6 +133,41 @@ namespace Restivus
             );
         }
 
+        /// <summary>
+        /// This overload's use is discouraged, as it can cause subtle misbehavior when
+        /// attempting to await a Task and only catch an Exception it may throw.
+        /// </summary>
+        /// <example>
+        /// try
+        /// {
+        ///     await restClient
+        ///         .SendAsync(
+        ///             HttpMethod.Get,
+        ///             "/health_check",
+        ///             request => { },
+        ///             async response =>
+        ///             {
+        ///                 if (_DetectFailureState(response))
+        ///                 {
+        ///                     var ex = await _ConvertFailedResponseToRelevantException(response);
+        ///                     throw ex;
+        ///                 }
+        ///
+        ///                 // The correctly intended overload will be chosen if you uncomment the
+        ///                 // following line, but callsites are bound to be missing this detail
+        ///                 //
+        ///                 // return Task.CompletedTask;
+        ///             },
+        ///             someCancellationToken);
+        /// }
+        /// catch (Exception ex)
+        /// {
+        ///     // Execution will not reach this spot.
+        /// }
+        ///
+        /// </example>
+        [Obsolete("Prefer deserializeResponseAsync overload")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Task<TResponse> SendAsync<TResponse>(
             this IRestClient client,
             HttpMethod method,


### PR DESCRIPTION
Can cause subtle issues when the deserialize callback is used only to throw an exception.