### PR TITLE
chore: Mark non-cancellable send methods obsolete

### DIFF
--- a/src/Restivus/HttpRequestSender.cs
+++ b/src/Restivus/HttpRequestSender.cs
@@ -9,15 +9,24 @@ using System.Threading.Tasks;
 
 namespace Restivus
 {
+    internal static class Deprecations
+    {
+        internal const string NO_CANCELLATION = "Prefer alternative accepting a System.Threading.CancellationToken";
+    }
+
     public interface IHttpRequestSender
     {
         HttpClient HttpClient { get; }
-        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
-        Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, Task<T>> deserializeResponseAsync);
         Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, Task<T>> deserializeResponseAsync, CancellationToken cancellationToken);
-        Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, T> deserializeResponse);
         Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, T> deserializeResponse, CancellationToken cancellationToken);
+
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
+        Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, T> deserializeResponse);
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
+        Task<T> SendAsync<T>(HttpRequestMessage request, Func<HttpResponseMessage, Task<T>> deserializeResponseAsync);
     }
 
     public partial class HttpRequestSender

--- a/src/Restivus/RestClient.cs
+++ b/src/Restivus/RestClient.cs
@@ -187,6 +187,7 @@ namespace Restivus
             );
         }
 
+        [Obsolete(Deprecations.NO_CANCELLATION)]
         public static Task<TResponse> SendAsync<TResponse>(
             this IRestClient client,
             HttpMethod method,

--- a/src/Restivus/SingleMethodRequestSender.cs
+++ b/src/Restivus/SingleMethodRequestSender.cs
@@ -13,104 +13,114 @@ namespace Restivus
     {
         HttpMethod HttpMethod { get; }
 
-        Task<string> SendAsync(string path);
-
         Task<string> SendAsync(string path, CancellationToken cancellationToken);
 
         Task<string> SendAsync(
             string path,
-            Action<HttpRequestMessage> mutateRequest);
-
-        Task<string> SendAsync(
-            string path,
             Action<HttpRequestMessage> mutateRequest,
             CancellationToken cancellationToken);
 
+        Task<string> SendAsync<TPayload>(
+            string path,
+            TPayload payload,
+            CancellationToken cancellationToken);
+
+        Task<string> SendAsync<TPayload>(
+            string path,
+            Func<TPayload> getPayload,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TResponse>(
+            string path,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TResponse>(
+            string path,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            TPayload payload,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            Func<TPayload> getPayload,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            TPayload payload,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        Task<TResponse> SendAsync<TPayload, TResponse>(
+            string path,
+            Func<TPayload> getPayload,
+            Action<HttpRequestMessage> mutateRequest,
+            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
+            CancellationToken cancellationToken);
+
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
+        Task<string> SendAsync(string path);
+
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<string> SendAsync<TPayload>(
             string path,
             TPayload payload);
 
-        Task<string> SendAsync<TPayload>(
-            string path,
-            TPayload payload,
-            CancellationToken cancellationToken);
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
+        Task<string> SendAsync(
+             string path,
+             Action<HttpRequestMessage> mutateRequest);
 
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<string> SendAsync<TPayload>(
             string path,
             Func<TPayload> getPayload);
 
-        Task<string> SendAsync<TPayload>(
-            string path,
-            Func<TPayload> getPayload,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TResponse>(
             string path,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
 
-        Task<TResponse> SendAsync<TResponse>(
-            string path,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TResponse>(
             string path,
             Action<HttpRequestMessage> mutateRequest,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
 
-        Task<TResponse> SendAsync<TResponse>(
-            string path,
-            Action<HttpRequestMessage> mutateRequest,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
             TPayload payload,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
 
-        Task<TResponse> SendAsync<TPayload, TResponse>(
-            string path,
-            TPayload payload,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
             Func<TPayload> getPayload,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
 
-        Task<TResponse> SendAsync<TPayload, TResponse>(
-            string path,
-            Func<TPayload> getPayload,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
             TPayload payload,
             Action<HttpRequestMessage> mutateRequest,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
 
-        Task<TResponse> SendAsync<TPayload, TResponse>(
-            string path,
-            TPayload payload,
-            Action<HttpRequestMessage> mutateRequest,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
-
+        [Obsolete(message: Deprecations.NO_CANCELLATION)]
         Task<TResponse> SendAsync<TPayload, TResponse>(
             string path,
             Func<TPayload> getPayload,
             Action<HttpRequestMessage> mutateRequest,
             Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync);
-
-        Task<TResponse> SendAsync<TPayload, TResponse>(
-            string path,
-            Func<TPayload> getPayload,
-            Action<HttpRequestMessage> mutateRequest,
-            Func<HttpResponseMessage, Task<TResponse>> deserializeResponseAsync,
-            CancellationToken cancellationToken);
     }
 
     public class SingleMethodRequestSender : ISingleMethodRequestSender


### PR DESCRIPTION
Trying an opinion that a CancellationToken should definitely be provided.