### PR TITLE
chore: Deprecate Serilog.ILogger

### DIFF
--- a/src/Restivus/HttpRequestSender.cs
+++ b/src/Restivus/HttpRequestSender.cs
@@ -44,6 +44,7 @@ namespace Restivus
 
         public HttpClient HttpClient { get; }
 
+        [Obsolete]
         public ILogger Logger { get; }
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) => SendAsync(request, Task.FromResult);


### PR DESCRIPTION
It's a strange dependency to hold, so it's probably just best sprinkled in through a middleware instead.